### PR TITLE
feat: Implementação do TrackIterator e correção do módulo principal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,8 +809,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy",
 ]
 
 [[package]]
@@ -820,7 +831,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -830,6 +851,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -926,7 +956,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "ref-cast",
  "rocket_codegen",
  "rocket_http",
@@ -1459,6 +1489,7 @@ dependencies = [
 name = "web-radio"
 version = "0.1.0"
 dependencies = [
+ "rand 0.9.0",
  "rocket",
  "soloud",
  "yaml-rust2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rand = "0.9.0"
 rocket = "0.5.1"
 soloud = "1.0.5"
 yaml-rust2 = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod objects;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use std::{
 
 #[macro_use]
 extern crate rocket;
-mod objects;
 
 // #[get("/")]
 // fn index() -> RawHtml<&'static [u8]> {

--- a/src/objects/track/track.rs
+++ b/src/objects/track/track.rs
@@ -1,6 +1,7 @@
 
+#[derive(Clone)]
 pub struct Track {
-    name: String,
-    file_format: String,
-    file_path: String,
+    pub name: String,
+    pub file_format: String,
+    pub file_path: String,
 }

--- a/src/objects/track/track_iterator.rs
+++ b/src/objects/track/track_iterator.rs
@@ -1,57 +1,76 @@
 // estrutura para armazenamento de estado anterior da estação
 
 use super::track::Track;
+use rand::seq::SliceRandom;
 use rand::{SeedableRng, Rng};
 use rand::rngs::StdRng;
 
-struct TrackIterator {
+pub struct TrackIterator {
     track: Track,
     track_queue: Vec<Track>,
     current_index: usize,
-    seed: u64,
+    _rng: StdRng,
+
 }
 
 impl TrackIterator {
-    fn new(track: Track, track_queue: Vec<Track>, seed: u64) -> Self {
+    pub fn new(mut track_queue: Vec<Track>, seed: u64) -> Self {
+
+        TrackIterator::shuffle_vec(&mut track_queue, seed);
+
+        let track = track_queue[0].clone();
+        track_queue.remove(0);
+
+        let _rng = StdRng::seed_from_u64(seed);
+
         TrackIterator {
             track,
             track_queue,
             current_index: 0,
-            seed
+            _rng
         }
     }
 
-    fn has_more(&self) -> bool {
-        self.track_queue.len() <= 1
+    pub fn has_more(&self) -> bool {
+        self.track_queue.len() >= 1
     }
 
-    fn go_next(&mut self) {
+    pub fn go_next(&mut self) {
         let nx_track = self.get_next();
         self.track = nx_track;
     }
 
-    fn get_next(&mut self) -> Track {
+    pub fn get_next(&mut self) -> Track {
+
+        if !self.has_more() {
+            panic!("No more tracks to play");
+        }
+
         self.shuffle();
         let next_index = self.pick_next();
 
-        let nx_track= self.track_queue[next_index];
+        let nx_track= self.track_queue[next_index].clone();
         self.track_queue.remove(next_index);
         nx_track
     }
 
     fn shuffle(&mut self) {
-        let mut rng = StdRng::seed_from_u64(self.seed);
-        rng.shuffle(&mut self.track_queue);
+        self.track_queue.shuffle(&mut self._rng);
     }
 
     fn pick_next(&mut self) -> usize {
-        let mut rng = StdRng::seed_from_u64(self.seed);
-        let next_index = rng.gen_range(0..self.track_queue.len());
+        let next_index = self._rng.random_range(0..self.track_queue.len());
         self.current_index = next_index;
         next_index
     }
 
-    fn get_current(&self) -> Track {
-        self.track
+    pub fn get_current(&self) -> &Track {
+        &self.track
+    }
+
+    pub fn shuffle_vec(vec: &mut Vec<Track>, seed: u64) {
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        vec.shuffle(&mut rng)
     }
 }

--- a/src/objects/track/track_iterator.rs
+++ b/src/objects/track/track_iterator.rs
@@ -1,9 +1,57 @@
 // estrutura para armazenamento de estado anterior da estação
 
 use super::track::Track;
+use rand::{SeedableRng, Rng};
+use rand::rngs::StdRng;
 
 struct TrackIterator {
     track: Track,
-    next_track: Track,
+    track_queue: Vec<Track>,
     current_index: usize,
+    seed: u64,
+}
+
+impl TrackIterator {
+    fn new(track: Track, track_queue: Vec<Track>, seed: u64) -> Self {
+        TrackIterator {
+            track,
+            track_queue,
+            current_index: 0,
+            seed
+        }
+    }
+
+    fn has_more(&self) -> bool {
+        self.track_queue.len() <= 1
+    }
+
+    fn go_next(&mut self) {
+        let nx_track = self.get_next();
+        self.track = nx_track;
+    }
+
+    fn get_next(&mut self) -> Track {
+        self.shuffle();
+        let next_index = self.pick_next();
+
+        let nx_track= self.track_queue[next_index];
+        self.track_queue.remove(next_index);
+        nx_track
+    }
+
+    fn shuffle(&mut self) {
+        let mut rng = StdRng::seed_from_u64(self.seed);
+        rng.shuffle(&mut self.track_queue);
+    }
+
+    fn pick_next(&mut self) -> usize {
+        let mut rng = StdRng::seed_from_u64(self.seed);
+        let next_index = rng.gen_range(0..self.track_queue.len());
+        self.current_index = next_index;
+        next_index
+    }
+
+    fn get_current(&self) -> Track {
+        self.track
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,11 @@
+mod test_track_iterator;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_track_iterator() {
+        test_track_iterator::tests_track_iterator::run_test();
+    }
+}

--- a/tests/test_track_iterator.rs
+++ b/tests/test_track_iterator.rs
@@ -1,0 +1,69 @@
+#[cfg(test)]
+pub mod tests_track_iterator {
+    use web_radio::objects::track::track_iterator::TrackIterator;
+    use web_radio::objects::track::track::Track;
+
+    pub fn run_test() {
+        test_track_iterator_initialization();
+        test_track_iterator_go_next();
+        test_track_iterator_has_more();
+    }
+
+    #[test]
+    fn test_track_iterator_initialization() {
+        let tracks = vec![
+            Track {
+                name: "Track 1".to_string(),
+                file_format: "mp3".to_string(),
+                file_path: "/path/to/track1.mp3".to_string(),
+            },
+            Track {
+                name: "Track 2".to_string(),
+                file_format: "mp3".to_string(),
+                file_path: "/path/to/track2.mp3".to_string(),
+            },
+        ];
+
+        let iterator = TrackIterator::new(tracks.clone(), 42);
+
+        assert_ne!(iterator.get_current().name, "");
+        assert_ne!(iterator.get_current().file_format, "");
+        assert_ne!(iterator.get_current().file_path, "");
+    }
+
+    #[test]
+    fn test_track_iterator_go_next() {
+        let tracks = vec![
+            Track {
+                name: "Track 1".to_string(),
+                file_format: "mp3".to_string(),
+                file_path: "/path/to/track1.mp3".to_string(),
+            },
+            Track {
+                name: "Track 2".to_string(),
+                file_format: "mp3".to_string(),
+                file_path: "/path/to/track2.mp3".to_string(),
+            },
+        ];
+
+        let mut iterator = TrackIterator::new(tracks.clone(), 42);
+
+        iterator.go_next();
+        assert_ne!(iterator.get_current().name, "");
+    }
+
+    #[test]
+    fn test_track_iterator_has_more() {
+        let tracks = vec![
+            Track {
+                name: "Track 1".to_string(),
+                file_format: "mp3".to_string(),
+                file_path: "/path/to/track1.mp3".to_string(),
+            },
+        ];
+
+        let mut iterator = TrackIterator::new(tracks.clone(), 42);
+
+        assert!(!iterator.has_more()); // Apenas um item, não há mais
+    }
+}


### PR DESCRIPTION
# Descrição

Fiz a implementação do módulo de track_iterator e em conjunto fiz testes automatizados para validar seu funcionamento.
Os testes ainda precisam ser melhorados mas ja é um inicio.
Também adicionei o arquivo de lib.rs para o web_radio ser acessível nos módulos de teste. Também modifiquei a estrutura de Track para os testes.

#3 Implementar o TrackIterator

## Tipo da mudança

- [x] New feature (Mudança que não quebra nenhum código atual e adiciona funcionalidade)

## Código de exemplo

O funcionamento do TrackIterator vai ser basicamente

```rust

 let iterator = TrackIterator::new(<Vec<Track>>, <Uma determinada seed em u64>);

// utilizando o get_current para pegar a track atual
iterator.get_current();

//utilizando o go_next para ir para a proxima musica, o go_next troca a track atual dentro do iterator
iterator.go_next();

```