### PR TITLE
fix: Correção que o lucas esqueceu de comentar

### DIFF
--- a/src/objects/track/track_iterator.rs
+++ b/src/objects/track/track_iterator.rs
@@ -4,6 +4,7 @@ use super::track::Track;
 use rand::seq::SliceRandom;
 use rand::{SeedableRng, Rng};
 use rand::rngs::StdRng;
+use core::result::Result;
 
 pub struct TrackIterator {
     track: Track,
@@ -32,26 +33,27 @@ impl TrackIterator {
     }
 
     pub fn has_more(&self) -> bool {
-        self.track_queue.len() >= 1
+        !self.track_queue.is_empty()
     }
 
-    pub fn go_next(&mut self) {
-        let nx_track = self.get_next();
+    pub fn go_next(&mut self) -> Result<(), &'static str> {
+        let nx_track = self.get_next()?;
         self.track = nx_track;
+        Ok(())
     }
-
-    pub fn get_next(&mut self) -> Track {
-
+    
+    pub fn get_next(&mut self) -> Result<Track, &'static str> {
         if !self.has_more() {
-            panic!("No more tracks to play");
+            return Err("No more tracks to play");
         }
-
+    
         self.shuffle();
         let next_index = self.pick_next();
-
-        let nx_track= self.track_queue[next_index].clone();
+    
+        // Usando clone para obter um valor owned
+        let nx_track = self.track_queue[next_index].clone();
         self.track_queue.remove(next_index);
-        nx_track
+        Ok(nx_track)
     }
 
     fn shuffle(&mut self) {


### PR DESCRIPTION
# Descrição
Corrigir as funções de get_next() e go_next() para que ele retorne um Result, ficando mais facil de saber se a pool de tracks se encerrou.

#3 Implementar o TrackIterator

## Tipo da mudança

- [x] Bug fix (Correção que não quebra nenhum código atual)

## Código de exemplo

A implementação ficou assim, agora sabemos se o get_next retornou um erro ou uma track, sem dar panic! para ser possível tratar mais facilmente.

```rust

pub fn go_next(&mut self) -> Result<(), &'static str> {
        let nx_track = self.get_next()?;
        self.track = nx_track;
        Ok(())
    }
    
    pub fn get_next(&mut self) -> Result<Track, &'static str> {
        if !self.has_more() {
            return Err("No more tracks to play");
        }
    
        self.shuffle();
        let next_index = self.pick_next();
    
        let nx_track = self.track_queue[next_index].clone();
        self.track_queue.remove(next_index);
        Ok(nx_track)
    }

```