### PR TITLE
fix: corrige uso de variáveis fora de escopo em new()

### DIFF
--- a/src/objects/radio.rs
+++ b/src/objects/radio.rs
@@ -1,6 +1,5 @@
-use std::collections::{hash_map, HashMap};
+use std::collections::HashMap;
 
-use rocket::time::Date;
 use super::{station::station::Station};
 
 struct Radio {
@@ -12,12 +11,12 @@ struct Radio {
 
 impl Radio {
 
-    fn new() -> Self {
+    fn new(seed: u64, _frequency: String) -> Self {
         Self {
             stations: HashMap::new(),
             seed,
             connections: 0,
-            _frequency, 
+            _frequency,
         }
     }
 


### PR DESCRIPTION
# Descrição

Não estava conseguindo rodar o projeto.

Adicionei os parâmetros `seed` e `_frequency` ao método `new` para evitar erro de compilação "cannot find value in this scope". 

![image](https://github.com/user-attachments/assets/e3ce22a6-a02e-4ea2-b60f-34e7397abc5c)

## Tipo da mudança

Delete as opções que não são relevantes

- [x] Bug fix (Correção que não quebra nenhum código atual)