### PR TITLE
feat: Decoder de arquivos de áudio usando ffmpeg + decoder WAV otimista

### DIFF
--- a/src/input_decoder/complex_codec.rs
+++ b/src/input_decoder/complex_codec.rs
@@ -17,8 +17,8 @@ pub struct ComplexCodecFile {
     reader: BufReader<ChildStdout>,
 }
 
-impl AudioFile for ComplexCodecFile {
-    fn new(file_path: String) -> ComplexCodecFile {
+impl ComplexCodecFile {
+    pub fn new(file_path: String) -> ComplexCodecFile {
         let file = File::open(file_path.clone()).expect("Failed to open file");
         let file_size = file.metadata().unwrap().len();
 
@@ -48,7 +48,9 @@ impl AudioFile for ComplexCodecFile {
             reader,
         }
     }
+}
 
+impl AudioFile for ComplexCodecFile {
     fn audio_file_path(&self) -> String {
         self.file_path.clone()
     }

--- a/src/input_decoder/input_audio_file.rs
+++ b/src/input_decoder/input_audio_file.rs
@@ -1,0 +1,18 @@
+pub trait AudioFile: Iterator {
+    fn new(file_path: String) -> Self;
+    fn audio_file_path(&self) -> String;
+    fn audio_file_size_bytes(&self) -> u64;
+}
+
+#[derive(Debug)]
+pub struct AudioPacket {
+    /**
+     * Quanto tempo de áudio este quadro tem, em segundos
+     */
+    pub audio_length: f64,
+
+    /**
+     * O buffer de áudio, formato PCM, com as especificações acima.
+     */
+    pub buffer: Vec<u8>,
+}

--- a/src/input_decoder/input_audio_file.rs
+++ b/src/input_decoder/input_audio_file.rs
@@ -4,6 +4,10 @@ pub trait AudioFile: Iterator {
     fn audio_file_size_bytes(&self) -> u64;
 }
 
+pub const CHANNEL_COUNT: u32 = 2;
+pub const SAMPLE_RATE: u32 = 44100;
+pub const BYTE_DEPTH: u32 = 2; //16bits
+
 #[derive(Debug)]
 pub struct AudioPacket {
     /**
@@ -15,4 +19,13 @@ pub struct AudioPacket {
      * O buffer de áudio, formato PCM, com as especificações acima.
      */
     pub buffer: Vec<u8>,
+}
+
+/// Converte o número de bytes de um buffer PCM para sua duração em segundos
+pub fn calculate_buffer_length(buffer_capacity_bytes: u32) -> f64 {
+    let bytes_per_sample = CHANNEL_COUNT * BYTE_DEPTH;
+    let samples_per_second = SAMPLE_RATE;
+    let buffer_length_seconds =
+        buffer_capacity_bytes as f64 / (bytes_per_sample as f64 * samples_per_second as f64);
+    buffer_length_seconds
 }

--- a/src/input_decoder/mod.rs
+++ b/src/input_decoder/mod.rs
@@ -1,0 +1,2 @@
+pub mod input_audio_file;
+pub mod mp3;

--- a/src/input_decoder/mod.rs
+++ b/src/input_decoder/mod.rs
@@ -1,2 +1,2 @@
+pub mod complex_codec;
 pub mod input_audio_file;
-pub mod mp3;

--- a/src/input_decoder/mod.rs
+++ b/src/input_decoder/mod.rs
@@ -1,2 +1,3 @@
 pub mod complex_codec;
 pub mod input_audio_file;
+pub mod wav_codec;

--- a/src/input_decoder/mp3.rs
+++ b/src/input_decoder/mp3.rs
@@ -1,0 +1,92 @@
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    process::{ChildStdout, Command, Stdio},
+};
+
+use super::input_audio_file::{AudioFile, AudioPacket};
+
+pub const CHANNEL_COUNT: u32 = 2;
+pub const SAMPLE_RATE: u32 = 44100;
+pub const BYTE_DEPTH: u32 = 2; //16bits
+
+pub const STDOUT_BUFFER_SIZE: u32 = SAMPLE_RATE * CHANNEL_COUNT * BYTE_DEPTH;
+
+/// Converte o número de bytes de um buffer PCM para sua duração em segundos
+fn calculate_buffer_length(buffer_capacity_bytes: u32) -> f64 {
+    let bytes_per_sample = CHANNEL_COUNT * BYTE_DEPTH;
+    let samples_per_second = SAMPLE_RATE;
+    let buffer_length_seconds =
+        buffer_capacity_bytes as f64 / (bytes_per_sample as f64 * samples_per_second as f64);
+    buffer_length_seconds
+}
+
+pub struct MP3File {
+    file_path: String,
+    file_size: u64,
+
+    reader: BufReader<ChildStdout>,
+}
+
+impl AudioFile for MP3File {
+    fn new(file_path: String) -> MP3File {
+        let file = File::open(file_path.clone()).expect("Failed to open file");
+        let file_size = file.metadata().unwrap().len();
+
+        let mut child = Command::new("ffmpeg")
+            .args(&[
+                "-i",
+                &file_path,
+                "-f",
+                "s16le",
+                "-ac",
+                &CHANNEL_COUNT.to_string(),
+                "-ar",
+                &SAMPLE_RATE.to_string(),
+                "-",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Falha ao spawnar o ffmpeg");
+
+        let stdout = child.stdout.take().expect("Falha ao ler stdout");
+        let reader = BufReader::new(stdout);
+
+        MP3File {
+            file_path,
+            file_size,
+            reader,
+        }
+    }
+
+    fn audio_file_path(&self) -> String {
+        self.file_path.clone()
+    }
+
+    fn audio_file_size_bytes(&self) -> u64 {
+        self.file_size
+    }
+}
+
+impl Iterator for MP3File {
+    type Item = AudioPacket;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut buffer = [0u8; STDOUT_BUFFER_SIZE as usize];
+        let n = self.reader.read(&mut buffer).expect("Falha ao ler bytes");
+
+        if n == 0 {
+            println!("EOF");
+            return None;
+        }
+
+        let audio_length = calculate_buffer_length(n as u32);
+        println!("{} bytes lidos ({:.4}s)", n, audio_length);
+
+        return Some(AudioPacket {
+            audio_length,
+            buffer: buffer[..n].to_vec(),
+        });
+    }
+}

--- a/src/input_decoder/wav_codec.rs
+++ b/src/input_decoder/wav_codec.rs
@@ -1,0 +1,73 @@
+use std::{
+    fs::File,
+    io::{Read, Seek},
+    ops::DerefMut,
+};
+
+use super::input_audio_file::{
+    calculate_buffer_length, AudioFile, AudioPacket, BYTE_DEPTH, CHANNEL_COUNT, SAMPLE_RATE,
+};
+
+const READ_BUFFER_SIZE: usize = (SAMPLE_RATE * CHANNEL_COUNT * BYTE_DEPTH) as usize;
+type ReadBuffer = [u8; READ_BUFFER_SIZE];
+
+pub struct WavCodecFile {
+    file_path: String,
+    file_size: u64,
+
+    file: File,
+    audio_buffer: Box<ReadBuffer>,
+}
+
+impl AudioFile for WavCodecFile {
+    fn new(file_path: String) -> WavCodecFile {
+        let mut file = File::open(file_path.clone())
+            .unwrap_or_else(|_| panic!("File {} is not readable?", file_path));
+        let file_size = file.metadata().expect("File has no metadata?").len();
+
+        // TODO: validar headers do wav, ver se o sample rate e outros parâmetros do arquivo são equivalentes ao contrato em input_audio_file
+        // TODO: (...validar aqui...)
+
+        // skipar header WAV, para não ler como se fosse áudio
+        file.seek(std::io::SeekFrom::Start(44))
+            .expect("Skipping WAV header failed");
+
+        WavCodecFile {
+            file_path,
+            file_size,
+            file,
+            audio_buffer: Box::new([0u8; READ_BUFFER_SIZE]),
+        }
+    }
+
+    fn audio_file_path(&self) -> String {
+        self.file_path.clone()
+    }
+
+    fn audio_file_size_bytes(&self) -> u64 {
+        self.file_size
+    }
+}
+
+impl Iterator for WavCodecFile {
+    type Item = AudioPacket;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let bytes_read = self
+            .file
+            .read(self.audio_buffer.deref_mut())
+            .expect("Audio file is unreadable");
+
+        if bytes_read == 0 {
+            println!("EOF.");
+            return None;
+        }
+
+        let packet = AudioPacket {
+            audio_length: calculate_buffer_length(bytes_read as u32),
+            buffer: self.audio_buffer[..bytes_read].to_vec(),
+        };
+
+        return Some(packet);
+    }
+}

--- a/src/input_decoder/wav_codec.rs
+++ b/src/input_decoder/wav_codec.rs
@@ -19,8 +19,8 @@ pub struct WavCodecFile {
     audio_buffer: Box<ReadBuffer>,
 }
 
-impl AudioFile for WavCodecFile {
-    fn new(file_path: String) -> WavCodecFile {
+impl WavCodecFile {
+    pub fn new(file_path: String) -> Self {
         let mut file = File::open(file_path.clone())
             .unwrap_or_else(|_| panic!("File {} is not readable?", file_path));
         let file_size = file.metadata().expect("File has no metadata?").len();
@@ -39,7 +39,9 @@ impl AudioFile for WavCodecFile {
             audio_buffer: Box::new([0u8; READ_BUFFER_SIZE]),
         }
     }
+}
 
+impl AudioFile for WavCodecFile {
     fn audio_file_path(&self) -> String {
         self.file_path.clone()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ use std::{
     time::Duration,
 };
 
+pub mod input_decoder;
+
 #[macro_use]
 extern crate rocket;
 
@@ -33,8 +35,6 @@ extern crate rocket;
 //     sender: broadcast::Sender<Box<[u8; POLL_BUFFER_SIZE_BYTES]>>,
 // }
 
-
-
 #[launch]
 fn rocket() -> _ {
     //let (tx, _) = broadcast::channel::<Box<[u8; POLL_BUFFER_SIZE_BYTES]>>(8);
@@ -46,7 +46,7 @@ fn rocket() -> _ {
     // let station_thread_clone = station.clone();
 
     rocket::build()
-        //.manage(broadcaster)
-        //.mount("/", routes![index, stylesheet])
-        //.mount("/station", routes![station_diamondcity])
+    //.manage(broadcaster)
+    //.mount("/", routes![index, stylesheet])
+    //.mount("/station", routes![station_diamondcity])
 }


### PR DESCRIPTION
# Descrição

Diferente da [DiamondCityRadio](https://github.com/lucas-bortoli/DiamondCityRadio), que usa arquivos .wav estritamente, a rádio atual toma como entrada arquivos de áudio comprimidos, em formatos diversos (.mp3, .ogg, etc). Esses arquivos de áudio precisam ser decodificados antes de consumir seu áudio.

- #5

## Tipo da mudança

Delete as opções que não são relevantes

- [ ] Bug fix (Correção que não quebra nenhum código atual)
- [x] New feature (Mudança que não quebra nenhum código atual e adiciona funcionalidade)
- [x] Breaking change (correção ou novo recurso que vai impactar código existente)
- [ ] Refactor (Uma alteração no código que não corrige um bug ou adiciona um recurso)