### PR TITLE
feat: adiciona conexao mock com cliente

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +967,7 @@ dependencies = [
  "rocket_codegen",
  "rocket_http",
  "serde",
+ "serde_json",
  "state",
  "tempfile",
  "time",
@@ -1489,9 +1496,12 @@ dependencies = [
 name = "web-radio"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "rand 0.9.0",
  "rocket",
+ "serde",
  "soloud",
+ "tokio",
  "yaml-rust2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [dependencies]
 rand = "0.9.0"
-rocket = "0.5.1"
 soloud = "1.0.5"
 yaml-rust2 = "0.10.0"
+rocket = { version = "0.5.1", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+base64 = "0.21.0"
+tokio = { version = "1", features = ["macros", "sync", "rt-multi-thread"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,46 +7,76 @@ use rocket::{
     tokio::sync::broadcast,
 };
 
-use std::{
-    fs::File,
-    io::{Read, Seek, SeekFrom},
-    ops::DerefMut,
-    sync::Arc,
-    thread,
-    time::Duration,
-};
-
 #[macro_use]
 extern crate rocket;
 
-// #[get("/")]
-// fn index() -> RawHtml<&'static [u8]> {
-//     return RawHtml(include_bytes!("ui.html"));
-// }
+use rocket::response::stream::{EventStream, Event};
+use rocket::serde::json::Json;
+use rocket::State;
+use std::sync::Arc;
+use tokio::sync::broadcast::{Sender};
+use serde::Serialize;
 
-// #[get("/ui.css")]
-// fn stylesheet() -> RawCss<&'static [u8]> {
-//     return RawCss(include_bytes!("ui.css"));
-// }
+// Estrutura que gerencia o broadcast de áudio
+struct AudioBroadcaster {
+    sender: Sender<Vec<u8>>,
+}
 
-// struct AudioBroadcaster {
-//     sender: broadcast::Sender<Box<[u8; POLL_BUFFER_SIZE_BYTES]>>,
-// }
+// Estrutura para metadados da estação (mock)
+#[derive(Serialize)]
+struct Metadata {
+    current_track: String,
+    subscribers: usize,
+    likes: usize,
+}
 
+#[get("/stream")]
+async fn stream(broadcaster: &State<Arc<AudioBroadcaster>>) -> EventStream![] {
+    // O padrão Observer é aplicado aqui: cada cliente se inscreve no canal de broadcast.
+    let mut rx = broadcaster.sender.subscribe();
+    EventStream! {
+        loop {
+            // Em um cenário real, chunks de áudio seriam enviados.
+            // Aqui usamos um mock para simular a transmissão.
+            match rx.recv().await {
+                Ok(chunk) => yield Event::data(base64::encode(&chunk)),
+                Err(_) => break,
+            }
+        }
+    }
+}
 
+// Endpoint para obter os metadados da estação
+#[get("/metadata")]
+fn metadata() -> Json<Metadata> {
+    // Os valores aqui são mock e servem para teste do frontend.
+    Json(Metadata {
+        current_track: "Faixa Exemplo".to_string(),
+        subscribers: 5,
+        likes: 10,
+    })
+}
 
 #[launch]
 fn rocket() -> _ {
-    //let (tx, _) = broadcast::channel::<Box<[u8; POLL_BUFFER_SIZE_BYTES]>>(8);
+    // Criação do canal de broadcast para áudio.
+    // O buffer de 8 mensagens é arbitrário e pode ser ajustado conforme a necessidade.
+    let (tx, _) = broadcast::channel::<Vec<u8>>(8);
 
-    //let broadcaster = Arc::new(AudioBroadcaster { sender: tx.clone() });
+    // enviando dados mock periodicamente em uma thread separada.
+    // Em uma implementação real, isso seria substituído pela lógica do iterator do AudioFile.
+    let broadcaster = Arc::new(AudioBroadcaster { sender: tx.clone() });
+    let broadcaster_clone = Arc::clone(&broadcaster);
 
-    // let station = Station::from_file("./diamond_city_radio/radio.yaml")
-    //     .expect("Failed to parse station file");
-    // let station_thread_clone = station.clone();
+    // Thread mock para envio de dados (simula o streaming de áudio)
+    std::thread::spawn(move || loop {
+        // Mock: dados de áudio simulados (em um cenário real, ler de um arquivo)
+        let mock_data = vec![0u8; 1024];
+        let _ = broadcaster_clone.sender.send(mock_data);
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    });
 
     rocket::build()
-        //.manage(broadcaster)
-        //.mount("/", routes![index, stylesheet])
-        //.mount("/station", routes![station_diamondcity])
+        .manage(broadcaster)
+        .mount("/", routes![stream, metadata])
 }


### PR DESCRIPTION
# Descrição

- **Endpoint de Streaming (`/stream`):**  
  - Utiliza um canal de broadcast para simular o envio de chunks de áudio.
  - A cada 500ms, uma thread separada envia dados mock (vetor de zeros) para os clientes conectados.
  - O padrão **Observer** é aplicado, permitindo que cada cliente se inscreva e receba os dados de áudio.
  
- **Endpoint de Metadados (`/metadata`):**  
  - Retorna um JSON com metadados mock da estação, como a faixa atual, número de subscribers e likes.
  
- **Estrutura de Broadcast:**  
  - A estrutura `AudioBroadcaster` encapsula o canal de broadcast usado para a transmissão de áudio.

## Dependências

1. **Implementação do Ponteiro de Execução (Iterator do AudioFile):**  
   - [Issue](https://github.com/Vinicius-de-Morais/web-radio/issues/5)

3. **Integração com o Estado Real da Estação:**  
   - Implementar o trait `StationState` com estados concretos (como `Playing`, `Paused`, `Stopped`).

4. **Refinamento da Lógica de Conexão e Broadcast:**  
   - Integrar a estrutura `Radio` e a lógica de gerenciamento de estações para que o streaming de áudio reflita o estado real da aplicação.
   - Implementar o Mediator para coordenar a comunicação entre a `Radio`, `Station` e `Subscribers`.

## Tipo da mudança

- [x] New feature (Mudança que não quebra nenhum código atual e adiciona funcionalidade)