### PR TITLE
feat: ffmpeg-based output audio encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,7 @@ dependencies = [
 name = "web-radio"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "rand 0.9.0",
  "rocket",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bytes = "1.10.1"
 rand = "0.9.0"
 rocket = "0.5.1"
 serde = "1.0.219"

--- a/src/cytoplasm/cytoplasm.rs
+++ b/src/cytoplasm/cytoplasm.rs
@@ -1,0 +1,125 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+use crate::{
+    input_decoder::input_audio_file::{self, AudioPacket},
+    output_encoder::{AudioEncoder, ProtectedConsumerVec},
+};
+
+pub struct Cytoplasm {
+    decoder_handle: JoinHandle<()>,
+    encoder_handle: JoinHandle<()>,
+
+    buffer: Arc<Mutex<VecDeque<AudioPacket>>>,
+}
+
+impl Cytoplasm {
+    pub fn new(mut audio_encoder: AudioEncoder) -> Cytoplasm {
+        let shared_buffer = Arc::new(Mutex::new(VecDeque::<AudioPacket>::new()));
+
+        const SETPOINT_LOW: usize = 1;
+        const SETPOINT_HIGH: usize = 10;
+
+        let decoder_buffer = shared_buffer.clone();
+        let decoder_handle = thread::spawn(move || loop {
+            let file = input_audio_file::open_input_file_strategy(
+                "./CorruptSaveLonelyHeart.mp3".to_string(),
+            );
+
+            for packet in file {
+                let mut buffer = decoder_buffer.lock().unwrap();
+                if buffer.len() >= SETPOINT_HIGH {
+                    eprintln!("cytoplasm/d: Backpressure!");
+
+                    drop(buffer); // liberar mutex imediatamente
+
+                    // fazer porra nenhuma até o buffer estar quase vazio
+                    'backpressure: loop {
+                        thread::sleep(Duration::from_millis(10));
+                        let buffer = decoder_buffer.lock().unwrap();
+                        if buffer.len() <= SETPOINT_LOW {
+                            eprintln!("cytoplasm/d: Backpressure acabou!");
+                            break 'backpressure;
+                        }
+                    }
+
+                    // finalmente continuar enfileirando pacotes
+                    decoder_buffer.lock().unwrap().push_back(packet);
+                } else {
+                    // enfileirar pacote imediatamente; ainda cabe no buffer
+                    buffer.push_back(packet);
+                }
+            }
+        });
+
+        let encoder_buffer = shared_buffer.clone();
+        let encoder_handle = thread::spawn(move || loop {
+            fn block_until_buffer_full(buffer: &Arc<Mutex<VecDeque<AudioPacket>>>) {
+                // fazer porra nenhuma até o buffer estar cheio
+                loop {
+                    thread::sleep(Duration::from_millis(10));
+                    let guard = buffer.lock().unwrap();
+                    if guard.len() >= SETPOINT_HIGH {
+                        // finalmente buffer cheio; a outra thread deve ter printado "BACKPRESSURE!!"
+                        eprintln!("cytoplasm/e: Buffering alcançado!");
+                        break;
+                    }
+                }
+            }
+
+            // inicialmente vamos deixar o buffer encher completamente, antes de começar a consumi-lo
+            // isso previne underruns durante o setup
+            block_until_buffer_full(&encoder_buffer);
+
+            let start = Instant::now();
+            let mut playback_time = 0.0;
+
+            loop {
+                let mut buffer = encoder_buffer.lock().unwrap();
+                if buffer.len() == 0 {
+                    eprintln!("cytoplasm/e: Underrun...");
+                    drop(buffer);
+                    block_until_buffer_full(&encoder_buffer);
+                } else {
+                    // consumir áudio
+                    let mut consumed_audio = Vec::new();
+                    while buffer.len() > SETPOINT_LOW {
+                        eprintln!("cytoplasm/e: consume...");
+                        consumed_audio.push(buffer.pop_front().unwrap());
+                    }
+
+                    // liberar mutex para que possam continuar enfileirando pacotes na outra thread
+                    drop(buffer);
+
+                    // transmitir o áudio, dar sleep
+                    for packet in consumed_audio {
+                        // send(packet); <--- TODO
+                        audio_encoder.push_audio_packet(&packet);
+                        playback_time += packet.audio_length;
+                    }
+
+                    // ao calcular o "next_time" com base em um start_time fixo, garantimos que pequenos atrasos não se acumulem ao longo do tempo.
+                    // usar apenas thread::sleep() pela duração de cada packet causaria desvios cumulativos, já que o tempo de execução de cada iteração varia.
+                    // assim, mesmo que uma iteração atrase um pouco, a próxima tentará se alinhar com o tempo real correto.
+                    let next_time = start + Duration::from_secs_f64(playback_time);
+                    let now = Instant::now();
+                    if next_time > now {
+                        thread::sleep(next_time - now);
+                    } else {
+                        eprintln!("cytoplasm/e: Time underrun...");
+                    }
+                }
+            }
+        });
+
+        return Cytoplasm {
+            buffer: shared_buffer,
+            decoder_handle,
+            encoder_handle,
+        };
+    }
+}

--- a/src/cytoplasm/mod.rs
+++ b/src/cytoplasm/mod.rs
@@ -1,0 +1,1 @@
+pub mod cytoplasm;

--- a/src/input_decoder/complex_codec.rs
+++ b/src/input_decoder/complex_codec.rs
@@ -4,6 +4,8 @@ use std::{
     process::{ChildStdout, Command, Stdio},
 };
 
+use bytes::Bytes;
+
 use crate::input_decoder::input_audio_file::calculate_buffer_length;
 
 use super::input_audio_file::{AudioFile, AudioPacket, BYTE_DEPTH, CHANNEL_COUNT, SAMPLE_RATE};
@@ -77,7 +79,7 @@ impl Iterator for ComplexCodecFile {
 
         return Some(AudioPacket {
             audio_length,
-            buffer: buffer[..n].to_vec(),
+            buffer: Bytes::copy_from_slice(&buffer[..n]),
         });
     }
 }

--- a/src/input_decoder/input_audio_file.rs
+++ b/src/input_decoder/input_audio_file.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use bytes::Bytes;
+
 use super::{complex_codec::ComplexCodecFile, wav_codec::WavCodecFile};
 
 pub const CHANNEL_COUNT: u32 = 2;
@@ -16,7 +18,7 @@ pub struct AudioPacket {
     /**
      * O buffer de áudio, formato PCM, com as especificações acima.
      */
-    pub buffer: Vec<u8>,
+    pub buffer: Bytes,
 }
 
 pub trait AudioFile: Iterator<Item = AudioPacket> {

--- a/src/input_decoder/wav_codec.rs
+++ b/src/input_decoder/wav_codec.rs
@@ -4,6 +4,8 @@ use std::{
     ops::DerefMut,
 };
 
+use bytes::Bytes;
+
 use super::input_audio_file::{
     calculate_buffer_length, AudioFile, AudioPacket, BYTE_DEPTH, CHANNEL_COUNT, SAMPLE_RATE,
 };
@@ -67,7 +69,7 @@ impl Iterator for WavCodecFile {
 
         let packet = AudioPacket {
             audio_length: calculate_buffer_length(bytes_read as u32),
-            buffer: self.audio_buffer[..bytes_read].to_vec(),
+            buffer: Bytes::copy_from_slice(&self.audio_buffer[..bytes_read]),
         };
 
         return Some(packet);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,13 @@
+use std::{
+    sync::{Arc, RwLock},
+    thread,
+    time::Duration,
+};
+
+use input_decoder::input_audio_file;
+use output_encoder::{ConsumerPacket, OutputCodec};
+use rocket::tokio::sync::{self};
+
 pub mod input_decoder;
 pub mod output_encoder;
 
@@ -17,19 +27,40 @@ extern crate rocket;
 // struct AudioBroadcaster {
 //     sender: broadcast::Sender<Box<[u8; POLL_BUFFER_SIZE_BYTES]>>,
 // }
+//
+//#[launch]
+//fn rocket() -> _ {
+//    //let (tx, _) = broadcast::channel::<Box<[u8; POLL_BUFFER_SIZE_BYTES]>>(8);
+//
+//    //let broadcaster = Arc::new(AudioBroadcaster { sender: tx.clone() });
+//
+//    // let station = Station::from_file("./diamond_city_radio/radio.yaml")
+//    //     .expect("Failed to parse station file");
+//    // let station_thread_clone = station.clone();
+//
+//    //rocket::build()
+//    //.manage(broadcaster)
+//    //.mount("/", routes![index, stylesheet])
+//    //.mount("/station", routes![station_diamondcity])
+//
+//    return (());
+//}
 
-#[launch]
-fn rocket() -> _ {
-    //let (tx, _) = broadcast::channel::<Box<[u8; POLL_BUFFER_SIZE_BYTES]>>(8);
+fn main() {
+    let (rx, tx) = sync::broadcast::channel::<ConsumerPacket>(8);
+    let station_subscribers = Arc::new(RwLock::new(vec![rx.clone()]));
+    let mut output =
+        output_encoder::AudioEncoder::new(OutputCodec::Mp3, station_subscribers.clone());
 
-    //let broadcaster = Arc::new(AudioBroadcaster { sender: tx.clone() });
+    loop {
+        let input =
+            input_audio_file::open_input_file_strategy("./CorruptSaveLonelyHeart.mp3".to_string());
 
-    // let station = Station::from_file("./diamond_city_radio/radio.yaml")
-    //     .expect("Failed to parse station file");
-    // let station_thread_clone = station.clone();
-
-    rocket::build()
-    //.manage(broadcaster)
-    //.mount("/", routes![index, stylesheet])
-    //.mount("/station", routes![station_diamondcity])
+        for packet in input {
+            println!("Áudio: {:.02}s", packet.audio_length);
+            //println!("{:?}", packet.buffer);
+            output.push_audio_packet(&packet);
+            // thread::sleep(Duration::from_millis((packet.audio_length * 1000.0) as u64));
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,17 +50,21 @@ fn main() {
     let (rx, tx) = sync::broadcast::channel::<ConsumerPacket>(8);
     let station_subscribers = Arc::new(RwLock::new(vec![rx.clone()]));
     let mut output =
-        output_encoder::AudioEncoder::new(OutputCodec::Mp3, station_subscribers.clone());
+        output_encoder::AudioEncoder::new(OutputCodec::Opus128kbps, station_subscribers.clone());
 
     loop {
-        let input =
-            input_audio_file::open_input_file_strategy("./CorruptSaveLonelyHeart.mp3".to_string());
+        let input = input_audio_file::open_input_file_strategy(
+            "./Blank Banshee - Gunshots.mp3".to_string(),
+        );
 
         for packet in input {
             println!("Áudio: {:.02}s", packet.audio_length);
             //println!("{:?}", packet.buffer);
             output.push_audio_packet(&packet);
-            // thread::sleep(Duration::from_millis((packet.audio_length * 1000.0) as u64));
+
+            thread::sleep(Duration::from_nanos(
+                (packet.audio_length * 1000_000_000.0) as u64,
+            ));
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,5 @@
-use rocket::{
-    http::ContentType,
-    response::{
-        content::{RawCss, RawHtml},
-        stream::ByteStream,
-    },
-    tokio::sync::broadcast,
-};
-
-use std::{
-    fs::File,
-    io::{Read, Seek, SeekFrom},
-    ops::DerefMut,
-    sync::Arc,
-    thread,
-    time::Duration,
-};
-
 pub mod input_decoder;
+pub mod output_encoder;
 
 #[macro_use]
 extern crate rocket;

--- a/src/output_encoder/mod.rs
+++ b/src/output_encoder/mod.rs
@@ -1,0 +1,111 @@
+use std::{
+    io::{BufReader, BufWriter, Read, Write},
+    process::{ChildStdin, Command, Stdio},
+    sync::{Arc, Mutex},
+    thread,
+};
+
+use rocket::tokio::sync::broadcast;
+
+use crate::input_decoder::input_audio_file::AudioPacket;
+
+pub const INPUT_CHANNEL_COUNT: u32 = 2;
+pub const INPUT_SAMPLE_RATE: u32 = 44100;
+pub const INPUT_BYTE_DEPTH: u32 = 2; //16bits
+
+pub const OUTPUT_CHANNEL_COUNT: u32 = 2;
+pub const OUTPUT_SAMPLE_RATE: u32 = 44100;
+pub const OUTPUT_BYTE_DEPTH: u32 = 2; //16bits
+
+pub const MAX_STATION_LISTENERS: usize = 64; // quantos players podem ouvir essa estação de uma vez?
+
+pub enum OutputCodec {
+    Mp3,
+    OggVorbis,
+    Opus,
+}
+
+type ConsumerPacket = Box<Vec<u8>>;
+type Consumer = broadcast::WeakSender<ConsumerPacket>;
+type ProtectedConsumerVec = Arc<Mutex<Vec<Consumer>>>;
+
+// singleton - um por estação
+pub struct AudioEncoder {
+    encoder_in: BufWriter<ChildStdin>,
+    consumers: ProtectedConsumerVec,
+}
+
+impl AudioEncoder {
+    pub fn new(output_codec: OutputCodec, consumers: ProtectedConsumerVec) -> AudioEncoder {
+        let mut child = Command::new("ffmpeg")
+            .args(&[
+                "-f",
+                "s16le",
+                "-ar",
+                &INPUT_SAMPLE_RATE.to_string(),
+                "-ac",
+                &INPUT_CHANNEL_COUNT.to_string(),
+                "-i",
+                "-", // stdin como input pro ffmpeg
+                "-f",
+                match output_codec {
+                    OutputCodec::Mp3 => "mp3",
+                    OutputCodec::OggVorbis => "ogg",
+                    OutputCodec::Opus => "opus",
+                },
+                "-", // stdout como output pro ffmpeg
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("encoder: Falha ao spawnar o ffmpeg");
+
+        let stdin = child.stdin.take().expect("encoder: Falha ao ler stdin");
+        let stdin_writer = BufWriter::new(stdin);
+        let stdout = child.stdout.take().expect("encoder: Falha ao ler stdout");
+        let mut stdout_reader = BufReader::new(stdout);
+
+        let encoder_consumers = consumers.clone();
+        thread::spawn(move || {
+            println!("encoder: Thread de consumidor de áudio iniciada.");
+
+            let mut buf = Vec::<u8>::new();
+            loop {
+                let n = stdout_reader
+                    .read(buf.as_mut())
+                    .expect("encoder: Ler stdout do encoder falhou - processo crashou?");
+
+                match n {
+                    0 => panic!("encoder: Stdout finalizou, estação acabou!"),
+                    1.. => {
+                        println!("encoder: {} bytes retornados do encoder!", n);
+
+                        let potential_consumers = encoder_consumers.lock().unwrap().to_vec();
+                        for potential_consumer in potential_consumers {
+                            if let Some(consumer) = potential_consumer.upgrade() {
+                                if let Err(e) = consumer.send(Box::new(buf[..n].to_vec())) {
+                                    eprintln!("encoder: Falha ao enviar para consumer: {:?}", e);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        AudioEncoder {
+            encoder_in: stdin_writer,
+            consumers,
+        }
+    }
+
+    pub fn push_audio_packet(&mut self, packet: AudioPacket) {
+        self.encoder_in
+            .write(&packet.buffer)
+            .expect("encoder: A fila do ffmpeg está cheia?");
+
+        // bypass do buffer do stdin; manda direto pro ffmpeg, já que áudio é em real-time e talvez não seja legal ter esse comportamento de buffering
+        // ignoramos o Result propositalmente, não há nenhuma ação cabível a ser tomada se o buffer de stdin não pode ser flushado - meio que não importa
+        let _ = self.encoder_in.flush();
+    }
+}


### PR DESCRIPTION
# Descrição

Diferente da [DiamondCityRadio](https://github.com/lucas-bortoli/DiamondCityRadio), que utiliza exclusivamente áudio no formato WAV e portanto não precisa fazer um transcoding entre formatos, essa rádio busca fornecer opções diversas de formatos de saída, buscando diminuir consumo de bandwidth em troca de maior consumo de CPU - uma escolha razoável.

Funciona assim: cada estação terá um único `AudioEncoder` (GoF Singleton), que recebe `AudioPacket`s periodicamente. O `AudioEncoder` cria um processo `ffmpeg` (#25) que recebe áudio PCM raw como stdin, e transforma em áudio encodado como stdout.

O `AudioEncoder` cria uma thread que constantemente tenta ler o `stdout` do `ffmpeg`, e quando recebe dados, encaminha para todos os consumidores (clientes da estação).

O `AudioEncoder` permite diversos codecs de saída, bem como bitrates distintas. Dessa forma, na rádio, podemos fornecer uma opção econômica em bandwidth, e uma opção mais pesada com mais qualidade de áudio.

## Tipo da mudança

- [x] New feature

## Referências

- https://trac.ffmpeg.org/wiki/audio%20types
- https://stackoverflow.com/a/22173931
- https://stackoverflow.com/a/45902691