### PR TITLE
feat: ajusta snapshot

### DIFF
--- a/src/objects/station/station_snapshot.rs
+++ b/src/objects/station/station_snapshot.rs
@@ -1,4 +1,4 @@
-use rocket::time::Date;
+use rocket::time:: OffsetDateTime;
 
 use crate::objects::{subscriber::Subscriber, track::track::Track};
 
@@ -6,5 +6,6 @@ pub struct StationSnapshot {
     pub name: String,
     pub current_track: Track,
     pub subscribers: Vec<Subscriber>,
-    pub created_on: Date,
+    pub created_on: OffsetDateTime,
+    pub duration_secs: f64, 
 }


### PR DESCRIPTION
# Descrição

A implementação do snapshot eu fiz no outro PR de station state mntes não havia registro nenhum sobre o que a estação já havia tocado nem por quanto tempo, só tínhamos a current_track em tempo real. Agora da para armazenar um histórico imutável de cada estado com “Histórico da rádio” e “Gerenciamento das faixas mais tocadas / pico de espectadores”.

## Tipo da mudança

- [x] New feature (Mudança que não quebra nenhum código atual e adiciona funcionalidade)