### PR TITLE
feat: sinaliza cytoplasm da next track

### DIFF
--- a/src/station/station.rs
+++ b/src/station/station.rs
@@ -68,6 +68,9 @@ impl Station {
         self.state = new_state;
 
         let _ = self.track_tx.send(self.current_track.clone());
+
+        print!("Atualizando track: ");
+        println!("{:#?}", self.current_track);
     }
 
     pub fn save_snapshot(&mut self) {


### PR DESCRIPTION
# Descrição

Foi adicionado uma função chamada **schedule_next_track** que basicament roda num thread::spawn paralelo, e a cada fim de faixa (ou seja, após dormir audio_milliseconds) faz next() na estação, que por sua vez manda o track_tx pro citoplasma. Por isso coloquei a Station agora como Arc<Mutex<Station>>

## Tipo da mudança

- [x] New feature (Mudança que não quebra nenhum código atual e adiciona funcionalidade)